### PR TITLE
Use Caddy for client and proxy server through it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,5 @@ gradle-app.setting
 **/build/
 
 # End of https://www.gitignore.io/api/node,java,linux,macos,gradle,windows,angular,code-java,sublimetext,jetbrains+all,visualstudiocode
+
+.caddy

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+0.0.0.0 {
+    log stdout
+    errors stdout
+
+    proxy /api localhost:4567
+    proxy / localhost:8000
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,0 @@
-0.0.0.0 {
-    log stdout
-    errors stdout
-
-    proxy /api localhost:4567
-    proxy / localhost:8000
-}

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+
+dist/node_modules
+dist/npm-debug.log

--- a/client/Caddyfile
+++ b/client/Caddyfile
@@ -1,0 +1,12 @@
+:80, :443 {
+    root /www/client
+
+    proxy /api server:4567
+
+    rewrite {
+      if {path} not_match ^/api
+      to {path} {path}/ /
+    }
+
+    gzip
+}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /tmp/client
 RUN npm install --no-interactive \
     && ng build --prod
 
-FROM nginx
-COPY --from=ngbuild /tmp/client/dist/client /usr/share/nginx/html
-HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
-  CMD wget --quiet --tries=1 --no-check-certificate --spider \
-  http://localhost:80 || exit 1
+FROM abiosoft/caddy
+COPY --from=ngbuild /tmp/client/dist/client /www/client
+COPY ./Caddyfile /etc/Caddyfile

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -1,8 +1,9 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { TestPageComponent } from './test-page/test-page.component';
 
 
-const routes: Routes = [];
+const routes: Routes = [{path: 'test', component: TestPageComponent}];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -3,10 +3,12 @@ import { NgModule } from '@angular/core';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { TestPageComponent } from './test-page/test-page.component';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    TestPageComponent
   ],
   imports: [
     BrowserModule,

--- a/client/src/app/test-page/test-page.component.html
+++ b/client/src/app/test-page/test-page.component.html
@@ -1,0 +1,1 @@
+<p>test-page works!</p>

--- a/client/src/app/test-page/test-page.component.spec.ts
+++ b/client/src/app/test-page/test-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TestPageComponent } from './test-page.component';
+
+describe('TestPageComponent', () => {
+  let component: TestPageComponent;
+  let fixture: ComponentFixture<TestPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TestPageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/test-page/test-page.component.ts
+++ b/client/src/app/test-page/test-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-test-page',
+  templateUrl: './test-page.component.html',
+  styleUrls: ['./test-page.component.scss']
+})
+export class TestPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,18 @@
+version: '3.7'
+services:
+  caddy:
+    image: "wemakeservices/caddy-docker:latest"
+    volumes:
+      - ./.caddy:/root/.caddy  # to save certificates on disk
+      - ./Caddyfile:/etc/Caddyfile  # to mount custom Caddyfile
+    ports:
+      - "2015:2015"
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - client
+
+  client:
+    build: ./client
+    ports:
+      - "8000:80"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,18 +1,11 @@
 version: '3.7'
 services:
-  caddy:
-    image: "wemakeservices/caddy-docker:latest"
+
+  client:
+    build: ./client
     volumes:
       - ./.caddy:/root/.caddy  # to save certificates on disk
-      - ./Caddyfile:/etc/Caddyfile  # to mount custom Caddyfile
     ports:
       - "2015:2015"
       - "80:80"
       - "443:443"
-    depends_on:
-      - client
-
-  client:
-    build: ./client
-    ports:
-      - "8000:80"


### PR DESCRIPTION
- Switch to Caddy base image in client/Dockerfile
- Setup Caddyfile to serve client files and proxy /api to the (not yet created) server
- Remove old Caddy image from docker-compose.prod.ymlc
- Add test page for testing routing in the client